### PR TITLE
fix(wifi-qr-code-generator)-add-wpa3-to-the-wpa-labels

### DIFF
--- a/src/tools/wifi-qr-code-generator/wifi-qr-code-generator.vue
+++ b/src/tools/wifi-qr-code-generator/wifi-qr-code-generator.vue
@@ -53,7 +53,7 @@ const { download } = useDownloadFileFromBase64({ source: qrcode, filename: 'qr-c
               value: 'nopass',
             },
             {
-              label: 'WPA/WPA2',
+              label: 'WPA/WPA2/WPA3',
               value: 'WPA',
             },
             {


### PR DESCRIPTION
null<br><br>**Note**: This PR incorporates contributions from upstream [PR-#1326](https://github.com/CorentinTh/it-tools/pull/1326) of [CorentinTh/it-tools](https://github.com/CorentinTh/it-tools). All original commits and authorship are retained. Some adjustments may have been made for compatibility or bug fixes.