### PR TITLE
add-memory-detection-to-dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@ FROM node:lts-alpine AS build-stage
 # Set environment variables for non-interactive npm installs
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV CI true
+
+# Detect available memory and set NODE_OPTIONS with buffer of 128MB
+RUN memory=$(awk '/MemTotal/{print $2}' /proc/meminfo); \
+    memory=$((memory / 1024 / 1024)); \
+    node_options="--max-old-space-size=$((memory - 128))"; \
+    export NODE_OPTIONS="$node_options";
+
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 RUN npm install -g pnpm && pnpm i --frozen-lockfile


### PR DESCRIPTION
This PR fixes the "JavaScript heap out of memory" error (issue #442) encountered during the build process. Now the Dockerfile will dynamically detect the available memory and set it to the [`--max-old-space-size`](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) Node option. It was tested on Raspberry Pi 4GB.<br><br>**Note**: This PR incorporates contributions from upstream [PR-#1073](https://github.com/CorentinTh/it-tools/pull/1073) of [CorentinTh/it-tools](https://github.com/CorentinTh/it-tools). All original commits and authorship are retained. Some adjustments may have been made for compatibility or bug fixes.