### PR TITLE
ci:-add-a-workflow-to-tag-pr-with-merge-conflicts

### DIFF
--- a/.github/workflows/pr-conflicts-tagger.yml
+++ b/.github/workflows/pr-conflicts-tagger.yml
@@ -1,0 +1,21 @@
+name: "Pull Requests Merge Conflicts Tagger"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@v3
+        with:
+          dirtyLabel: "PR: needs rebase"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those before we can evaluate the pull request."
+#          commentOnClean: "Conflicts have been resolved. A maintainer will review the pull request shortly."


### PR DESCRIPTION
This will allow the PR author to be notified and resolve merge conflicts as soon as they arrive

Source : https://github.com/orgs/community/discussions/23152<br><br>**Note**: This PR incorporates contributions from upstream [PR-#1282](https://github.com/CorentinTh/it-tools/pull/1282) of [CorentinTh/it-tools](https://github.com/CorentinTh/it-tools). All original commits and authorship are retained. Some adjustments may have been made for compatibility or bug fixes.