### PR TITLE
feat(ci):-use-node-version-from-.nvmrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version-file: '.nvmrc' # Use the node version specified in .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/docker-nightly-release.yml
+++ b/.github/workflows/docker-nightly-release.yml
@@ -32,7 +32,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version-file: '.nvmrc' # Use the node version specified in .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version-file: '.nvmrc' # Use the node version specified in .nvmrc
           cache: 'pnpm'
 
       - name: Get Playwright version

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version-file: '.nvmrc' # Use the node version specified in .nvmrc
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,2 @@
-18.18.2
+# workflows use this version of Node.js
+20.17.0


### PR DESCRIPTION
https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file

Updated version in `.nvmrc` to latest v20<br><br>**Note**: This PR incorporates contributions from upstream [PR-#1272](https://github.com/CorentinTh/it-tools/pull/1272) of [CorentinTh/it-tools](https://github.com/CorentinTh/it-tools). All original commits and authorship are retained. Some adjustments may have been made for compatibility or bug fixes.