### PR TITLE
feat:-setup-crowdin

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,40 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Crowdin Sync
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'locales/en.yml'
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Crowdin
+        uses: crowdin/github-action@v1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: true
+          # Download translations from Crowdin
+          download_translations: true
+          # Create a pull request with new translations
+          create_pull_request: true
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: main
+          localization_branch_name: l10n_crowdin_translations
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,12 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "locales/en.yml",
+    "translation": "locales/%two_letters_code%.yml"
+  }
+]


### PR DESCRIPTION
Hey everyone,

It's Andrii from Crowdin. Just stumbled across issue #790 and decided to suggest an automated way to synchronize localization resources between Crowdin and the repository. The community translators can work together in Crowdin, translations would be delivered as PR and volunteers can raise issues for problematic strings via Crowdin.

I'm suggesting the integration with [Crowdin via GitHub Actions](https://github.com/crowdin/github-action). Crowdin is free for open-source projects. This integration works in the following way:
- the action runs when some changes are being pushed for the `locales/en.yml` file in the `main` branch
- upload new source texts to the Crowdin project
- upload existing translations to Crowdin (using the `upload_translations` action config parameter, it's necessary only for the first time)
- download all the new translations from Crowdin and commit these translations to the `l10n_crowdin_translations` branch
- open a Pull Request with the latest translations.

You can find my demo Crowdin project here - [it-tools-demo](https://crowdin.com/project/it-tools-demo).

Example of the first PR that will be created by Crowdin Action - https://github.com/andrii-bodnar/it-tools/pull/1 (Don't worry about the diffs - it's just updated the translation files to the actual state. The next PRs will include the new translations only).

By the way, I found an already created project in Crowdin - https://crowdin.com/project/it-tools 🙂 

Closes: #790<br><br>**Note**: This PR incorporates contributions from upstream [PR-#1086](https://github.com/CorentinTh/it-tools/pull/1086) of [CorentinTh/it-tools](https://github.com/CorentinTh/it-tools). All original commits and authorship are retained. Some adjustments may have been made for compatibility or bug fixes.