### PR TITLE
fix(uuid-generator):-prevent-textarea-height-increase-on-refresh

### DIFF
--- a/src/tools/uuid-generator/uuid-generator.vue
+++ b/src/tools/uuid-generator/uuid-generator.vue
@@ -104,7 +104,6 @@ const { copy } = useCopy({ source: uuids, text: 'UUIDs copied to the clipboard' 
       class="uuid-display"
     />
 
-
     <div flex justify-center gap-3>
       <c-button autofocus @click="copy()">
         Copy


### PR DESCRIPTION
The height of the textarea in the UUID Generator component was increasing with each refresh. This commit fixes the issue by using the quantity of UUIDs generated as the row property of the textarea and also removes the autosize property of the textarea.

Problem:

https://github.com/CorentinTh/it-tools/assets/67636853/192e67f3-36d0-447b-9182-a7739d6d0086

Solution:

1. Removed the autosize property of the textarea
2. Set the number of rows of the textarea to the quantity of UUIDs generated

Fix #1063 

<br><br>**Note**: This PR incorporates contributions from upstream [PR-#1064](https://github.com/CorentinTh/it-tools/pull/1064) of [CorentinTh/it-tools](https://github.com/CorentinTh/it-tools). All original commits and authorship are retained. Some adjustments may have been made for compatibility or bug fixes.